### PR TITLE
Define TP_STATUS_CSUM_VALID when not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(ZeekPluginAF_Packet)
 
 include(ZeekPlugin)
+include(CheckSymbolExists)
 
 zeek_plugin_begin(Zeek AF_Packet)
 zeek_plugin_cc(src/Plugin.cc)
@@ -12,6 +13,11 @@ zeek_plugin_cc(src/RX_Ring.cc)
 zeek_plugin_bif(src/af_packet.bif)
 zeek_plugin_dist_files(zeekctl/af_packet.py README COPYING VERSION)
 zeek_plugin_end()
+
+check_symbol_exists(TP_STATUS_CSUM_VALID linux/if_packet.h HAVE_TP_STATUS_CSUM_VALID)
+if (NOT HAVE_TP_STATUS_CSUM_VALID)
+    message(STATUS "Checksum offloading to the kernel might not be fully supported.")
+endif ()
 
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" VERSION LIMIT_COUNT 1)
 

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -6,6 +6,12 @@
 
 #include "af_packet.bif.h"
 
+// CentOS 7 if_packet.h does not yet have this define, provide it
+// explicitly if missing.
+#ifndef TP_STATUS_CSUM_VALID
+#define TP_STATUS_CSUM_VALID (1 << 7)
+#endif
+
 using namespace zeek::iosource::pktsrc;
 
 AF_PacketSource::~AF_PacketSource()


### PR DESCRIPTION
On some older Linux distributions (CentOS 7), the if_packet.h header does not yet include TP_STATUS_CSUM_VALID (introduced in March 2015). Simply define it if it's not there.