### PR TITLE
RX_Ring: Add include for string

### DIFF
--- a/src/RX_Ring.h
+++ b/src/RX_Ring.h
@@ -8,6 +8,7 @@ extern "C" {
 }
 #include <stdint.h>
 #include <stdexcept>
+#include <string>
 
 #define TPACKET_VERSION TPACKET_V3
 


### PR DESCRIPTION
When compiling with clang and libc++ like done when using Google's hongfuzz in the oss-fuzz setup, the following errors are produced:

    Step #3 - "compile-honggfuzz-address-x86_64": /src/zeek/auxil/zeek-af_packet-plugin/src/RX_Ring.cc:19:9: error: no matching conversion for functional-style cast from 'const char[15]' to 'RX_RingException'
    Step #3 - "compile-honggfuzz-address-x86_64":                 throw RX_RingException("invalid socket");
    Step #3 - "compile-honggfuzz-address-x86_64":                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Step #3 - "compile-honggfuzz-address-x86_64": /src/zeek/auxil/zeek-af_packet-plugin/src/RX_Ring.h:14:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'const char[15]' to 'const RX_RingException' for 1st argument
    Step #3 - "compile-honggfuzz-address-x86_64": class RX_RingException : public std::runtime_error {
    Step #3 - "compile-honggfuzz-address-x86_64":       ^
    Step #3 - "compile-honggfuzz-address-x86_64": /src/zeek/auxil/zeek-af_packet-plugin/src/RX_Ring.h:14:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'const char[15]' to 'RX_RingException' for 1st argument
    Step #3 - "compile-honggfuzz-address-x86_64": /src/zeek/auxil/zeek-af_packet-plugin/src/RX_Ring.h:16:2: note: candidate constructor not viable: no known conversion from 'const char[15]' to 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char>>') for 1st argument
    Step #3 - "compile-honggfuzz-address-x86_64":         RX_RingException(const std::string& what_arg) : std::runtime_error(what_arg) {}
    Step #3 - "compile-honggfuzz-address-x86_64":

The problem can be reproduced outside of hongfuzz by compiling this plugin with with clang/libc++:

    export CXX=clang++-14
    export CXXFLAGS=-stdlib=libc++
    ./configure
    make

Include <string> in RX_Ring.h to ensure the required const char * to std::string conversion are available to any users of RX_RingException.