### PR TITLE
Add zeek/zeek-version.h fallback.

### DIFF
--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -1,6 +1,13 @@
 
 #include "zeek/zeek-config.h"
 
+// Starting with Zeek 6.0, zeek-config.h does not provide the
+// ZEEK_VERSION_NUMBER macro anymore when compiling a included
+// plugin. Use the new zeek/zeek-version.h header if it exists.
+#if __has_include("zeek/zeek-version.h")
+#include "zeek/zeek-version.h"
+#endif
+
 #include "AF_Packet.h"
 #include "RX_Ring.h"
 


### PR DESCRIPTION
With zeek/zeek#2802, zeek-config.h will not provide ZEEK_VERSION_NUMBER when a plugin is compiled as a builtin/static plugin into Zeek. This is done to avoid tree-wide ccache busting when just the version changes.