### PR TITLE
Use action-zkg-install@v2, only run actions on PR and master pushes

### DIFF
--- a/.github/workflows/zeek-matrix.yml
+++ b/.github/workflows/zeek-matrix.yml
@@ -16,7 +16,7 @@ jobs:
         zeekver: [zeek, zeek-lts, zeek-nightly]
     steps:
       - uses: actions/checkout@v3
-      - uses: zeek/action-zkg-install@v1.2
+      - uses: awelzel/action-zkg-install@v2
         with:
           zeek_version: ${{ matrix.zeekver }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/zeek-matrix.yml
+++ b/.github/workflows/zeek-matrix.yml
@@ -2,6 +2,8 @@ name: Zeek matrix tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently, the GitHub actions run for pushes to any branch, rather than just master or PRs.

Also, bump to action-zkg-install@v2 for git safe.directory fix.