### PR TITLE
AF_Packet: Check interface for upness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Build the plugin against the latest zeekurity/zeek-dev image
-ARG IMAGE=zeekurity/zeek-dev:latest
+ARG IMAGE=zeek/zeek:5.0.7
 FROM $IMAGE
 
 RUN apt-get update && apt-get -y --no-install-recommends install \

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -106,7 +106,7 @@ void AF_PacketSource::Open()
 	Opened(props);
 	}
 
-inline bool AF_PacketSource::BindInterface()
+bool AF_PacketSource::BindInterface()
 	{
 	struct ifreq ifr;
 	struct sockaddr_ll saddr_ll;
@@ -128,7 +128,7 @@ inline bool AF_PacketSource::BindInterface()
 	return (ret >= 0);
 	}
 
-inline bool AF_PacketSource::EnablePromiscMode()
+bool AF_PacketSource::EnablePromiscMode()
 	{
 	struct ifreq ifr;
 	struct packet_mreq mreq;
@@ -149,7 +149,7 @@ inline bool AF_PacketSource::EnablePromiscMode()
 	return (ret >= 0);
 	}
 
-inline bool AF_PacketSource::ConfigureFanoutGroup(bool enabled, bool defrag)
+bool AF_PacketSource::ConfigureFanoutGroup(bool enabled, bool defrag)
 	{
 	if ( enabled )
 		{
@@ -168,7 +168,7 @@ inline bool AF_PacketSource::ConfigureFanoutGroup(bool enabled, bool defrag)
 	return true;
 	}
 
-inline bool AF_PacketSource::ConfigureHWTimestamping(bool enabled)
+bool AF_PacketSource::ConfigureHWTimestamping(bool enabled)
 	{
 	if ( enabled )
 		{
@@ -196,7 +196,7 @@ inline bool AF_PacketSource::ConfigureHWTimestamping(bool enabled)
 	return true;
 	}
 
-inline uint32_t AF_PacketSource::GetFanoutMode(bool defrag)
+uint32_t AF_PacketSource::GetFanoutMode(bool defrag)
 	{
 	uint32_t fanout_mode;
 

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -35,6 +35,9 @@ AF_PacketSource::AF_PacketSource(const std::string& path, bool is_live)
 	props.path = path;
 	props.is_live = is_live;
 
+	socket_fd = -1;
+	rx_ring = nullptr;
+
 	checksum_mode = zeek::BifConst::AF_Packet::checksum_validation_mode->AsEnum();
 	}
 
@@ -227,12 +230,14 @@ uint32_t AF_PacketSource::GetFanoutMode(bool defrag)
 
 void AF_PacketSource::Close()
 	{
-	if ( ! socket_fd )
+	if ( socket_fd < 0 )
 		return;
 
 	delete rx_ring;
+	rx_ring = nullptr;
+
 	close(socket_fd);
-	socket_fd = 0;
+	socket_fd = -1;
 
 	Closed();
 	}

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -60,6 +60,24 @@ void AF_PacketSource::Open()
 		return;
 		}
 
+	auto info = GetInterfaceInfo(props.path);
+
+	if ( ! info.Valid() )
+		{
+		Error(errno ? strerror(errno) : "unable to get interface information");
+		close(socket_fd);
+		socket_fd = -1;
+		return;
+		}
+
+	if ( ! info.IsUp() )
+		{
+		Error("interface is down");
+		close(socket_fd);
+		socket_fd = -1;
+		return;
+		}
+
 	// Create RX-ring
 	try {
 		rx_ring = new RX_Ring(socket_fd, buffer_size, block_size, block_timeout_msec);
@@ -70,14 +88,14 @@ void AF_PacketSource::Open()
 	}
 
 	// Setup interface
-	if ( ! BindInterface() )
+	if ( ! BindInterface(info) )
 		{
 		Error(errno ? strerror(errno) : "unable to bind to interface");
 		close(socket_fd);
 		return;
 		}
 
-	if ( ! EnablePromiscMode() )
+	if ( ! EnablePromiscMode(info) )
 		{
 		Error(errno ? strerror(errno) : "unable enter promiscious mode");
 		close(socket_fd);
@@ -109,43 +127,51 @@ void AF_PacketSource::Open()
 	Opened(props);
 	}
 
-bool AF_PacketSource::BindInterface()
+AF_PacketSource::InterfaceInfo AF_PacketSource::GetInterfaceInfo(const std::string& path)
 	{
+	AF_PacketSource::InterfaceInfo info;
 	struct ifreq ifr;
-	struct sockaddr_ll saddr_ll;
 	int ret;
 
 	memset(&ifr, 0, sizeof(ifr));
-	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", props.path.c_str());
+	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", path.c_str());
+
+	ret = ioctl(socket_fd, SIOCGIFFLAGS, &ifr);
+	if ( ret < 0 )
+		return info;
+
+	info.flags = ifr.ifr_flags;
 
 	ret = ioctl(socket_fd, SIOCGIFINDEX, &ifr);
 	if ( ret < 0 )
-		return false;
+		return info;
+
+	info.index = ifr.ifr_ifindex;
+
+	return info;
+	}
+
+bool AF_PacketSource::BindInterface(const AF_PacketSource::InterfaceInfo& info)
+	{
+	struct sockaddr_ll saddr_ll;
+	int ret;
 
 	memset(&saddr_ll, 0, sizeof(saddr_ll));
 	saddr_ll.sll_family = AF_PACKET;
 	saddr_ll.sll_protocol = htons(ETH_P_ALL);
-	saddr_ll.sll_ifindex = ifr.ifr_ifindex;
+	saddr_ll.sll_ifindex = info.index;
 
 	ret = bind(socket_fd, (struct sockaddr *) &saddr_ll, sizeof(saddr_ll));
 	return (ret >= 0);
 	}
 
-bool AF_PacketSource::EnablePromiscMode()
+bool AF_PacketSource::EnablePromiscMode(const AF_PacketSource::InterfaceInfo& info)
 	{
-	struct ifreq ifr;
 	struct packet_mreq mreq;
 	int ret;
 
-	memset(&ifr, 0, sizeof(ifr));
-	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", props.path.c_str());
-
-	ret = ioctl(socket_fd, SIOCGIFINDEX, &ifr);
-	if ( ret < 0 )
-		return false;
-
 	memset(&mreq, 0, sizeof(mreq));
-	mreq.mr_ifindex = ifr.ifr_ifindex;
+	mreq.mr_ifindex = info.index;
 	mreq.mr_type = PACKET_MR_PROMISC;
 
 	ret = setsockopt(socket_fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, &mreq, sizeof(mreq));

--- a/src/AF_Packet.h
+++ b/src/AF_Packet.h
@@ -66,8 +66,17 @@ private:
 	RX_Ring *rx_ring;
 	struct pcap_pkthdr current_hdr;
 
-	bool BindInterface();
-	bool EnablePromiscMode();
+	struct InterfaceInfo {
+		int index = -1;
+		int flags = 0;
+
+		bool Valid () { return index >= 0; }
+		bool IsUp() { return flags & IFF_UP; }
+	};
+
+	InterfaceInfo GetInterfaceInfo(const std::string& path);
+	bool BindInterface(const InterfaceInfo& info);
+	bool EnablePromiscMode(const InterfaceInfo& info);
 	bool ConfigureFanoutGroup(bool enabled, bool defrag);
 	bool ConfigureHWTimestamping(bool enabled);
 	uint32_t GetFanoutMode(bool defrag);


### PR DESCRIPTION

When using af_packet with an interface that was not up, the following
non-informative error was reported:

    $ /opt/zeek-5.2/bin/zeek -i af_packet::replay
    fatal error: problem with interface af_packet::replay (Invalid argument)

With this change, the error now includes information about the
interface being down:

    $ ZEEK_PLUGIN_PATH=$(pwd)/build zeek -Ci af_packet::replay
    fatal error: problem with interface af_packet::replay (interface is down)

Fixes #51
