### PR TITLE
Fix wrong vlan when PCP or DEI bits are set in tp_vlan_tci

### DIFF
--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -296,7 +296,7 @@ bool AF_PacketSource::ExtractNextPacket(zeek::Packet* pkt)
 		pkt->Init(props.link_type, &current_hdr.ts, current_hdr.caplen, current_hdr.len, data);
 
 		if ( packet->tp_status & TP_STATUS_VLAN_VALID )
-			pkt->vlan = packet->hv1.tp_vlan_tci;
+			pkt->vlan = packet->hv1.tp_vlan_tci & 0x0fff;
 
 #if ZEEK_VERSION_NUMBER >= 50100
 		switch ( checksum_mode )


### PR DESCRIPTION
A user reported vlan ids > 4095 being logged by Zeek [1]. For populating
packet->vlan, mask away Priority Code Point (PCP) and Drop Eligible
Indicator (DEI) bits from the tp_vlan_tci field, else we're not setting
the correct value on the packet.

Fixes #60

[1] https://community.zeek.org/t/zeek-reporting-vlan-ids-above-4095-bug-found/7000