### PR TITLE
Require CMake 3.15 to match Zeek's requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(ZeekPluginAF_Packet)
 


### PR DESCRIPTION
This fixes this warning when building Zeek with af_packet included:

```
CMake Deprecation Warning at auxil/zeek-af_packet-plugin/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```